### PR TITLE
Add support for absolute positioning

### DIFF
--- a/Snooper/Rendering/Actors/LevelActor.cs
+++ b/Snooper/Rendering/Actors/LevelActor.cs
@@ -126,6 +126,9 @@ public class LevelActor : Actor
                         break;
                     }
                 }
+                component.UseAbsolutePosition = sceneComponent.GetOrDefault("bAbsoluteLocation", false);
+                component.UseAbsoluteRotation = sceneComponent.GetOrDefault("bAbsoluteRotation", false);
+                component.UseAbsoluteScale = sceneComponent.GetOrDefault("bAbsoluteScale", false);
                 break;
             }
             default:

--- a/Snooper/Rendering/Actors/MeshActor.cs
+++ b/Snooper/Rendering/Actors/MeshActor.cs
@@ -45,7 +45,10 @@ public class MeshActor : Actor
         using (mesh) MeshComponent = new StaticMeshComponent(landscape, mesh);
         
         MeshComponent.LocalTransform = component.GetRelativeTransform();
-        
+        MeshComponent.UseAbsolutePosition = component.GetOrDefault("bAbsoluteLocation", false);
+        MeshComponent.UseAbsoluteRotation = component.GetOrDefault("bAbsoluteRotation", false);
+        MeshComponent.UseAbsoluteScale = component.GetOrDefault("bAbsoluteScale", false);
+
         Components.Add(MeshComponent);
     }
 

--- a/Snooper/Rendering/Components/PrimitiveComponent.cs
+++ b/Snooper/Rendering/Components/PrimitiveComponent.cs
@@ -59,7 +59,16 @@ public abstract class PrimitiveComponent<TVertex, TInstanceData, TPerDrawData> :
         var data = new TInstanceData[LocalInstanceTransforms.Count];
         for (var i = 0; i < data.Length; i++)
         {
-            data[i] = new TInstanceData { Matrix = LocalInstanceTransforms[i].ToMatrix() * relation };
+            Matrix4x4 instanceMatr;
+            if (Relation != null && (UseAbsolutePosition || UseAbsoluteRotation || UseAbsoluteScale))
+            {
+                instanceMatr = BuildWorldTransform(LocalInstanceTransforms[i]).ToMatrix();
+            }
+            else
+            {
+                instanceMatr = LocalInstanceTransforms[i].ToMatrix() * relation;
+            }
+            data[i] = new TInstanceData { Matrix = instanceMatr };
         }
         
         if (_cachedInstanceData is null)

--- a/Snooper/Rendering/Components/Transforms/SpatialComponent.cs
+++ b/Snooper/Rendering/Components/Transforms/SpatialComponent.cs
@@ -32,7 +32,24 @@ public class SpatialComponent(Transform? transform = null, string? name = null) 
             MarkDirty();
         }
     }
-    
+
+    public bool UseAbsolutePosition { get; set; }
+    public bool UseAbsoluteRotation { get; set; }
+    public bool UseAbsoluteScale { get; set; }
+
+    private Transform? _worldTransform = null;
+    public Transform WorldTransform
+    {
+        get
+        {
+            if (_worldTransform != null)
+                return _worldTransform;
+            UpdateWorldTransform();
+            return _worldTransform ?? LocalTransform;
+        }
+        private set => _worldTransform = value;
+    }
+
     private Matrix4x4 _worldMatrix = Matrix4x4.Identity;
     public Matrix4x4 WorldMatrix
     {
@@ -82,7 +99,41 @@ public class SpatialComponent(Transform? transform = null, string? name = null) 
     {
         LocalMatrix = LocalTransform.ToMatrix();
     }
-    
+
+    protected Transform BuildWorldTransform(Transform localTransform)
+    {
+        if (Relation is null)
+        {
+            return LocalTransform;
+        }
+        else
+        {
+            var ret = new Transform();
+
+            if (UseAbsoluteRotation)
+                ret.Rotation = localTransform.Rotation;
+            else
+                ret.Rotation = Relation.WorldTransform.Rotation * localTransform.Rotation;
+
+            if (UseAbsoluteScale)
+                ret.Scale = localTransform.Scale;
+            else
+                ret.Scale = localTransform.Scale * Relation.WorldTransform.Scale;
+
+            if (UseAbsolutePosition)
+            {
+                ret.Position = localTransform.Position;
+            }
+            else
+            {
+                Relation.UpdateWorldMatrix();
+                ret.Position = Vector3.Transform(localTransform.Position, Relation.WorldMatrix);
+            }
+
+            return ret;
+        }
+    }
+
     private void UpdateWorldMatrixInternal(bool recursive)
     {
         if (Relation is null)
@@ -92,12 +143,22 @@ public class SpatialComponent(Transform? transform = null, string? name = null) 
         else
         {
             if (recursive) Relation.UpdateWorldMatrix();
-            WorldMatrix = LocalMatrix * Relation.WorldMatrix;
+
+            if (UseAbsoluteRotation || UseAbsoluteScale || UseAbsolutePosition)
+            {
+                WorldMatrix = WorldTransform.ToMatrix();
+            }
+            else
+            {
+                WorldMatrix = LocalMatrix * Relation.WorldMatrix;
+            }
         }
     }
 
     internal override void MarkDirty()
     {
+        _worldTransform = null;
+
         base.MarkDirty();
         
         foreach (var child in Children)


### PR DESCRIPTION
Unreal supports specifying the scale, position, or rotation as absolute, so add support for that as well. This requires the world transform itself to be propagated, not just the matrix derived from it. Since computing the matrix is noticably faster, I've implemented calculation of the WorldTransform as a lazy operation, so it will only be calculated for the few components that need it, rather than for the entire scene.